### PR TITLE
Fix keyword arguments warnings on Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 
 rvm:
   - 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,6 @@
 language: ruby
+
+rvm:
+  - 2.5
+  - 2.6
+  - 2.7

--- a/lib/simpacker/context.rb
+++ b/lib/simpacker/context.rb
@@ -8,7 +8,7 @@ module Simpacker
 
     def initialize(root_path: Rails.root, env: Rails.env)
       config = load_config_file(root_path, env)
-      @config = Simpacker::Configuration.new(config)
+      @config = Simpacker::Configuration.new(**config)
       @manifest = Simpacker::Manifest.new(@config)
     end
 


### PR DESCRIPTION
I add Ruby 2.7 settings to `.travis.yml` to check warnings, then I fix the warnings.