### PR TITLE
Fix parcelrc to enable default parcel reporter

### DIFF
--- a/example/parcel2/.parcelrc
+++ b/example/parcel2/.parcelrc
@@ -1,4 +1,4 @@
 {
   "extends": "@parcel/config-default",
-  "reporters": ["parcel-reporter-bundle-manifest"]
+  "reporters": ["...", "parcel-reporter-bundle-manifest"]
 }

--- a/example/parcel2/README.md
+++ b/example/parcel2/README.md
@@ -54,8 +54,14 @@ export function hello(name) {
 <script src="./application.js"></script>
 ```
 
+### .parcelrc
+
+Add `parcel-reporter-bundle-manifest` to `.parcelrc` in `reporters`.
+
+https://github.com/autifyhq/parcel-reporter-bundle-manifest#usage
+
 ## Run parcel
 
 ```
-$ ./node_modules/.bin/parcel serve --dist-dir public/packs --public-url /packs app/javascript/index.html
+$ ./node_modules/.bin/parcel --dist-dir public/packs --public-url /packs app/javascript/index.html
 ```


### PR DESCRIPTION
Fix wrong setting for parcel in example/parcel2 (added #68 )

This pull request resolves the problem `parcel serve` fails to listen http.

```
❯ npm run start

> start
> parcel serve --dist-dir public/packs --public-url /packs app/javascript/index.html

Server running at http://localhost:1234
✨ Built in 132ms
console: 📄 Wrote bundle manifest to: /path/to/parcel-manifest.json

❯ curl localhost:1234
curl: (7) Failed to connect to localhost port 1234: Connection refused
```