### PR TITLE
Support ruby 3.1

### DIFF
--- a/lib/simpacker/context.rb
+++ b/lib/simpacker/context.rb
@@ -16,7 +16,11 @@ module Simpacker
 
     def load_config_file(root_path, env)
       config_path = root_path.join("config/simpacker.yml")
-      yaml = YAML.load(config_path.read)
+      yaml = begin
+               YAML.load(config_path.read, aliases: true)
+             rescue ArgumentError
+               YAML.load(config_path.read)
+             end
       config_env = yaml.fetch(env.to_s)
       {
         manifest_path: root_path.join(config_env.fetch('manifest_path')),


### PR DESCRIPTION
In Ruby 3.1, Psych gem is updated to v4, and Psych v4 changes `Psych.load` to use `safe_load` by default.
https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/

So option `aliases: true` must be given to use YAML aliases.
(But Psych v3 does not accept this option.)

I referred to https://github.com/rails/rails/pull/42249 before creating this patch.

---

By the way, this project's CI has been stopped from 9743aa83a5d5bc25b09a93abafd94e041a9722a8, because:

> Since June 15th, 2021, the building on travis-ci.org is ceased.
 