### PR TITLE
Fixes test code that fails when running tests in the latest Rails.

### DIFF
--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -9,7 +9,7 @@ class HelperTest < ActionView::TestCase
   end
 
   def test_stylesheet_pack_tag
-    assert_equal '<link rel="stylesheet" media="screen" href="/packs/application.css" />', stylesheet_pack_tag('application')
+    assert_equal '<link rel="stylesheet" href="/packs/application.css" media="screen" />', stylesheet_pack_tag('application')
   end
 
   def test_image_pack_tag

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -21,6 +21,6 @@ class HelperTest < ActionView::TestCase
   end
 
   def test_favicon_pack_tag
-    assert_equal '<link rel="shortcut icon" type="image/x-icon" href="/packs/images/favicon.ico" />', favicon_pack_tag('favicon.ico')
+    assert_equal '<link rel="icon" type="image/x-icon" href="/packs/images/favicon.ico" />', favicon_pack_tag('favicon.ico')
   end
 end


### PR DESCRIPTION
This PR is a fix for test code that fails when running tests in the latest Rails.

How about this PR?

### Description

The test failed when I checked out the latest code from the `master` branch and ran the test as follows. 

```ruby
$ bundle install
$ bundle exec rails --version                                                          
Rails 7.0.1
$ bundle exec rake test
F

Failure:
HelperTest#test_favicon_pack_tag [/Users/jun.morita/Documents/repo/simpacker/test/helper_test.rb:24]:
--- expected
+++ actual
@@ -1 +1 @@
-"<link rel=\"shortcut icon\" type=\"image/x-icon\" href=\"/packs/images/favicon.ico\" />"
+"<link rel=\"icon\" type=\"image/x-icon\" href=\"/packs/images/favicon.ico\" />"

rails test /Users/jun.morita/Documents/repo/simpacker/test/helper_test.rb:23

...F

Failure:
HelperTest#test_stylesheet_pack_tag [/Users/jun.morita/Documents/repo/simpacker/test/helper_test.rb:12]:
--- expected
+++ actual
@@ -1 +1 @@
-"<link rel=\"stylesheet\" media=\"screen\" href=\"/packs/application.css\" />"
+"<link rel=\"stylesheet\" href=\"/packs/application.css\" media=\"screen\" />"

rails test /Users/jun.morita/Documents/repo/simpacker/test/helper_test.rb:11

.......

Finished in 0.025286s, 474.5709 runs/s, 514.1185 assertions/s.
12 runs, 13 assertions, 2 failures, 0 errors, 0 skips
```

The cause of the problem was something that occurred in Rails 7, so we fixed the expectation to match the latest specification. (Please check the commit comment for details).

* 83696a79ba44c7b4eac5273634d208a2fddab1ac
* 352dfdde4e06a092f8c0b22b77a375a3074fcd33

### Test

I have confirmed that the test passes in my local environment.

```
$ bundle exec rake test
Run options: --seed 17130

# Running:

............

Finished in 0.007339s, 1635.1001 runs/s, 1771.3585 assertions/s.
12 runs, 13 assertions, 0 failures, 0 errors, 0 skips
```
