### PR TITLE
Migrated ci from Travis CI to GitHub Actions workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: ["2.7", "3.0", "3.1"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: install dependencies
+        run: bundle install --jobs 3 --retry 3
+      - name: test
+        run: bundle exec rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: ruby
-cache: bundler
-
-rvm:
-  - 2.5
-  - 2.6
-  - 2.7
-  - 3.0


### PR DESCRIPTION
This is a PR to migrate to GitHub Action, please close this PR if considering migrating to travis-ci.com, etc.

How about this PR?

### Description

This repository is currently using https://travis-ci.org/. However, https://travis-ci.org/ was terminated on June 15, 2021.

> Since June 15th, 2021, the building on travis-ci.org is ceased. Please use travis-ci.com from now on.
> https://travis-ci.org/github/hokaccha/simpacker

Therefore, I moved to GitHub Action to restart CI.

I also excluded ruby 2.5, 2.6 which is not supported latest stable Rails.

```ruby
  s.required_ruby_version     = ">= 2.7.0"
```

ref: https://github.com/rails/rails/blob/v7.0.1/rails.gemspec#L12

### Test

I have confirmed that the Github Action runs and succeeds in my repository.

https://github.com/madogiwa0124/simpacker/actions/runs/1687653248