### PR TITLE
Add GitHub actions for status badge to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Simpacker
 
+[![CI](https://github.com/hokaccha/simpacker/actions/workflows/ci.yml/badge.svg)](https://github.com/hokaccha/simpacker/actions/workflows/ci.yml)
 [![Gem Version](https://badge.fury.io/rb/simpacker.svg)](https://badge.fury.io/rb/simpacker)
 
 Simpacker provides the feature to integrate modern JavaScript build system with Rails, like a [webpacker](https://github.com/rails/webpacker).


### PR DESCRIPTION
This is a PR to changed to status badge to show the result of the GitHub action.

How about this PR?

### Test

I have confirmed that the Github Action result badge appears in my repository.

https://github.com/madogiwa0124/simpacker/blob/add-github-action-status-badge/README.md