### PR TITLE
fixed `test_image_pack_url` for latest rails.

### DIFF
--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -17,7 +17,7 @@ class HelperTest < ActionView::TestCase
   end
 
   def test_image_pack_url
-    assert_equal '/packs/images/favicon.ico', image_pack_url('favicon.ico')
+    assert_equal 'http://test.host/packs/images/favicon.ico', image_pack_url('favicon.ico')
   end
 
   def test_favicon_pack_tag


### PR DESCRIPTION
This PR is a fix for test code that fails when running tests in the latest Rails.

### Description

It seems that the `asset_url` in the test environment has been changed to include the host since Rails v7.0.3.

I thought asset_url was expected to return a url containing the host, so I fixed the expectation.

```
$ bundle exec rails -v
Rails 7.0.2.4

$ bundle exec rake test

............

Finished in 0.005473s, 2192.5818 runs/s, 2375.2969 assertions/s.
12 runs, 13 assertions, 0 failures, 0 errors, 0 skips

$ bundle exec rails -v
Rails 7.0.3

$ bundle exec rake test

..F

Failure:
HelperTest#test_image_pack_url [simpacker/test/helper_test.rb:20]:
--- expected
+++ actual
@@ -1 +1 @@
-"/packs/images/favicon.ico"
+"http://test.host/packs/images/favicon.ico"
```

ref: https://github.com/madogiwa0124/simpacker/actions/runs/5294948578/jobs/9584806634

### Test

I have confirmed that the test passes in my local environment and GitHub Action in my repository.

```
$ bundle exec rake test 
............

Finished in 0.007398s, 1622.0600 runs/s, 1757.2317 assertions/s.
12 runs, 13 assertions, 0 failures, 0 errors, 0 skips
```

https://github.com/madogiwa0124/simpacker/actions/runs/5295234442

By the way, the value of `asset_url(simpacker_context.manifest.lookup!(name), **options)` did not differ between Rails versions.

```diff
    def image_pack_url(name, **options)
++    p asset_url(simpacker_context.manifest.lookup!(name), **options)
      asset_url(simpacker_context.manifest.lookup!(name), **options)
    end
```

```console
$ bundle exec rails -v
# => Rails 7.0.2.4

$ bundle exec rake test
# => ........."/packs/images/favicon.ico"

$ bundle exec rails -v
# => Rails 7.0.3

$ bundle exec rake test
# => .."/packs/images/favicon.ico"
```